### PR TITLE
Give Single a result type parameter.

### DIFF
--- a/taskgroup_test.go
+++ b/taskgroup_test.go
@@ -171,6 +171,26 @@ func TestSingleTask(t *testing.T) {
 	g.Wait()
 }
 
+func TestSingleResult(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	release := make(chan struct{})
+
+	s := taskgroup.Call(func() (int, error) {
+		<-release
+		return 25, nil
+	})
+	time.AfterFunc(2*time.Millisecond, func() { close(release) })
+
+	res := s.Wait()
+	if res.Err != nil {
+		t.Errorf("Unexpected error: %v", res.Err)
+	}
+	if res.Value != 25 {
+		t.Errorf("Result: got %v, want 25", res.Value)
+	}
+}
+
 type peakValue struct {
 	μ        sync.Mutex
 	cur, max int


### PR DESCRIPTION
- Convert Single into Single[T].
- Update Go to generate Single[error].
- Add a compound result type Result[T].
- Add a Call helper to run a Single[Result[T]].

Existing usage of Go and Single is not changed.
