### PR TITLE
taskgroup: drop *Group from the signature of start functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ A task is expressed as a `func() error`, and is added to a group using the `Go`
 method:
 
 ```go
-g := taskgroup.New(nil).Go(myTask)
+var g taskgroup.Group
+g.Go(myTask)
 ```
 
 Any number of tasks may be added, and it is safe to do so from multiple

--- a/example_test.go
+++ b/example_test.go
@@ -187,24 +187,24 @@ func ExampleCollector_Report() {
 	}
 	c := taskgroup.Collect(func(z val) { fmt.Println(z.who, z.v) })
 
-	err := taskgroup.New(nil).
-		// The Report method passes its argument a function to report multiple
-		// values to the collector.
-		Go(c.Report(func(report func(v val)) error {
-			for i := range 3 {
-				report(val{"even", 2 * i})
-			}
-			return nil
-		})).
-		// Multiple reporters are fine.
-		Go(c.Report(func(report func(v val)) error {
-			for i := range 3 {
-				report(val{"odd", 2*i + 1})
-			}
-			// An error from a reporter is propagated like any other task error.
-			return errors.New("no bueno")
-		})).
-		Wait()
+	g := taskgroup.New(nil)
+	// The Report method passes its argument a function to report multiple
+	// values to the collector.
+	g.Go(c.Report(func(report func(v val)) error {
+		for i := range 3 {
+			report(val{"even", 2 * i})
+		}
+		return nil
+	}))
+	// Multiple reporters are fine.
+	g.Go(c.Report(func(report func(v val)) error {
+		for i := range 3 {
+			report(val{"odd", 2*i + 1})
+		}
+		// An error from a reporter is propagated like any other task error.
+		return errors.New("no bueno")
+	}))
+	err := g.Wait()
 	if err == nil || err.Error() != "no bueno" {
 		log.Fatalf("Unexpected error: %v", err)
 	}

--- a/taskgroup.go
+++ b/taskgroup.go
@@ -55,8 +55,8 @@ func (g *Group) activate() {
 // manipulate local data structures without additional locking.
 func New(ef ErrorFunc) *Group { return &Group{onError: ef} }
 
-// Go runs task in a new goroutine in g, and returns g to permit chaining.
-func (g *Group) Go(task Task) *Group {
+// Go runs task in a new goroutine in g.
+func (g *Group) Go(task Task) {
 	g.wg.Add(1)
 	if g.active.Load() == 0 {
 		g.activate()
@@ -67,14 +67,13 @@ func (g *Group) Go(task Task) *Group {
 			g.handleError(err)
 		}
 	}()
-	return g
 }
 
 // Run runs task in a new goroutine in g, and returns g to permit chaining.
 // This is shorthand for:
 //
 //	g.Go(taskgroup.NoError(task))
-func (g *Group) Run(task func()) *Group { return g.Go(NoError(task)) }
+func (g *Group) Run(task func()) { g.Go(NoError(task)) }
 
 func (g *Group) handleError(err error) {
 	g.μ.Lock()


### PR DESCRIPTION
While it is mildly convenient in a few cases to chain construction of the group
with starting a goroutine, it has turned out not to be worthwhile in practice.
Apart from the tests (which are hereby updated not to do that anymore), a
search of GitHub suggests nobody uses this -- even in code I wrote.
