### PR TITLE
taskgroup: deprecate Trigger and Listen

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -40,7 +40,7 @@ func ExampleTrigger() {
 	const badTask = 5
 
 	// Construct a group in which any task error cancels the context.
-	g := taskgroup.New(taskgroup.Trigger(cancel))
+	g := taskgroup.New(cancel)
 
 	for i := range 10 {
 		g.Go(func() error {
@@ -67,10 +67,11 @@ func ExampleTrigger() {
 func ExampleListen() {
 	// The taskgroup itself will only report the first non-nil task error, but
 	// you can use an error listener used to accumulate all of them.
+	// Calls to the listener are synchronized, so we don't need a lock.
 	var all []error
-	g := taskgroup.New(taskgroup.Listen(func(e error) {
+	g := taskgroup.New(func(e error) {
 		all = append(all, e)
-	}))
+	})
 	g.Go(func() error { return errors.New("badness 1") })
 	g.Go(func() error { return errors.New("badness 2") })
 	g.Go(func() error { return errors.New("badness 3") })

--- a/examples/copytree/copytree.go
+++ b/examples/copytree/copytree.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	g, start := taskgroup.New(taskgroup.Trigger(cancel)).Limit(*maxWorkers)
+	g, start := taskgroup.New(cancel).Limit(*maxWorkers)
 
 	err := filepath.Walk(*srcPath, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
Instead of making the caller explicitly adapt functions to the error filter
interface, make the OnError method (and thereby the New constructor) accept an
argument of dynamic type and do the adaptation automatically.

For now, the Trigger and Listen helpers are still present, but marked as
deprecated. I will remove them in a future release once known existing use is
updated.
